### PR TITLE
object-to-object ETL package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+before_script:
+  - composer self-update
+  - composer update --no-interaction $COMPOSER_OPTS
+script:
+  - vendor/bin/phing
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/abacaphiliac/zend-transformer/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/abacaphiliac/zend-transformer/?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/abacaphiliac/zend-transformer/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/abacaphiliac/zend-transformer/?branch=master)
+[![Build Status](https://travis-ci.org/abacaphiliac/zend-transformer.svg?branch=master)](https://travis-ci.org/abacaphiliac/zend-transformer)
+
+# abacaphiliac/zend-transformer
+An object-to-object ETL package, based on Zend Framework extraction, hydration, and validation abstractions.
+
+Includes a PluginManager for registering transformation specs via application config, and a ZF2 module to wire up all configuration.
+
+Requires >=php55, and supports ZF2 but not ZF3 at this time.
+
+# Installation
+```bash
+composer require abacaphiliac/zend-transformer
+```
+
+# Usage
+
+Register transformers in your application config:
+
+```php
+return [
+    'abacaphiliac/zend-transformer' => [
+        'transformers' => [
+            'SimpleFooBarToFizBuz' => [
+                'inputClass' => \AbacaphiliacTest\FooBar::class,
+                'keyMap' => [
+                    'foo' => 'fiz',
+                    'bar' => 'buz',
+                ],
+                'outputClass' => \AbacaphiliacTest\FizBuz::class,
+            ],
+        ],
+    ],
+];
+```
+
+Transform some data!
+
+```php
+$transformers = $serviceLocator->get('TransformerManager');
+$transformer = $transformers->get('SimpleFooBarToFizBuz');
+
+$input = new \AbacaphiliacTest\FooBar('Foo', 'Bar');
+$output = $transformer->transform($input, \AbacaphiliacTest\FizBuz::class);
+```
+
+Complex configuration:
+
+```php
+return [
+    'abacaphiliac/zend-transformer' => [
+        'transformers' => [
+            'ComplexFooBarToFizBuz' => [
+                'input_validator' => 'MyInputValidatorFromValidatorManager',
+                'extractor' => 'MyExractorFromHydratorManager',
+                'transformer' => 'MyTransformerFromServiceManager',
+                'hydrator' => 'MyHydratorFromHydratorManager',
+                'output_validator' => 'MyOutputValidatorFromValidatorManager',
+            ],
+        ],
+    ],
+    'service_manager' => [
+        'invokables' => [
+            'MyTransformerFromServiceManager' => function (array $data) {
+                // Don't do this in production, as the config cannot be cached.
+                return [];
+            },
+        ],
+    ],
+    'validators' => [
+        'invokables' => [
+            'MyInputValidatorFromValidatorManager' => \Zend\Validator\ValidatorChain::class,
+            'MyOutputValidatorFromValidatorManager' => \Zend\Validator\ValidatorChain::class,
+        ],
+    ],
+    'hydrators' => [
+        'invokables' => [
+            'MyExractorFromHydratorManager' => \Zend\Hydrator\ClassMethods::class,
+            'MyHydratorFromHydratorManager' => \Zend\Hydrator\ClassMethods::class,
+        ],
+    ],
+];
+```
+
+## Contributing
+```
+composer update && vendor/bin/phpunit
+```
+
+This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If
+you notice compliance oversights, please send a patch via pull request.
+
+[PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
+[PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+[PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,41 @@
+<project name="abacaphiliac/zend-transformer" default="develop" basedir=".">
+    
+    <target name="develop">
+        <phingcall target="lint"/>
+        <phingcall target="tests"/>
+    </target>
+
+    <target name="lint">
+        <phingcall target="php-lint"/>
+        <phingcall target="phpcs"/>
+    </target>
+
+    <target name="php-lint">
+        <exec command="vendor/bin/parallel-lint src tests"
+              passthru="true"
+              output="/dev/stdout"
+              error="/dev/stdout"
+              checkreturn="true"/>
+    </target>
+
+    <target name="phpcs">
+        <exec command="vendor/bin/phpcs --standard=PSR2 --extensions=php --severity=1 --colors -p config/ src/ tests/"
+              passthru="true"
+              output="/dev/stdout"
+              error="/dev/stdout"
+              checkreturn="true"/>
+    </target>
+    
+    <target name="tests">
+        <phingcall target="unit-tests"/>
+    </target>
+    
+    <target name="unit-tests">
+        <exec command="vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover"
+            passthru="true"
+            output="/dev/stdout"
+            error="/dev/stdout"
+            checkreturn="true"/>
+    </target>
+    
+</project>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "abacaphiliac/zend-transformer",
+    "description": "Extract and Hydrate, plus secret sauce.",
+    "minimum-stability": "stable",
+    "license": "proprietary",
+    "authors": [
+        {
+            "name": "Timothy Younger",
+            "email": "abacaphiliac@gmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.5",
+        "zendframework/zend-filter": "^2.0",
+        "zendframework/zend-hydrator": "^2.0",
+        "zendframework/zend-modulemanager": "^2.0",
+        "zendframework/zend-mvc": "^2.0",
+        "zendframework/zend-servicemanager": "^2.0",
+        "zendframework/zend-validator": "^2.0",
+        "igorw/get-in": "^1.0",
+        "beberlei/assert": "^2.6"
+    },
+    "require-dev": {
+        "phing/phing": "^2.15",
+        "jakub-onderka/php-parallel-lint": "^0.9",
+        "squizlabs/php_codesniffer": "^2.8",
+        "phpunit/phpunit": "^5.7|^4.8"
+    },
+    "autoload": {
+        "psr-4": {
+            "Abacaphiliac\\Zend\\Transformer\\": "src/ZendTransformer"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "AbacaphiliacTest\\": "tests/ZendTransformer"
+        }
+    }
+}

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'service_manager' => [
+        'factories' => [
+            'TransformerManager' => \Abacaphiliac\Zend\Transformer\PluginManager\TransformerPluginManagerFactory::class,
+        ],
+    ],
+    'abacaphiliac/zend-transformer' => [
+        'transformers' => [
+            
+        ],
+    ],
+];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<phpunit bootstrap="vendor/autoload.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         disallowChangesToGlobalState="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="abacaphiliac/zend-transformer">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/ZendTransformer/Config/TransformerConfig.php
+++ b/src/ZendTransformer/Config/TransformerConfig.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer\Config;
+
+use Abacaphiliac\Zend\Transformer\TransformerInterface;
+use Zend\Hydrator\ExtractionInterface;
+use Zend\Hydrator\HydrationInterface;
+use Zend\Stdlib\AbstractOptions;
+use Zend\Validator\ValidatorInterface;
+
+class TransformerConfig extends AbstractOptions
+{
+    /** @var string|null */
+    private $inputClass;
+    
+    /** @var ValidatorInterface|string|null */
+    private $inputValidator;
+    
+    /** @var ExtractionInterface|string|null */
+    private $extractor;
+    
+    /** @var mixed[]|null */
+    private $keyMap;
+    
+    /** @var TransformerInterface|callable|string|null */
+    private $transformer;
+    
+    /** @var HydrationInterface|string|null */
+    private $hydrator;
+    
+    /** @var string|null */
+    private $outputClass;
+    
+    /** @var ValidatorInterface|string|null */
+    private $outputValidator;
+    
+    /**
+     * @return null|string
+     */
+    public function getInputClass()
+    {
+        return $this->inputClass;
+    }
+    
+    /**
+     * @param null|string $inputClass
+     * @return void
+     */
+    public function setInputClass($inputClass)
+    {
+        $this->inputClass = $inputClass;
+    }
+    
+    /**
+     * @return null|string
+     */
+    public function getInputValidator()
+    {
+        return $this->inputValidator;
+    }
+    
+    /**
+     * @param null|string $inputValidator
+     * @return void
+     */
+    public function setInputValidator($inputValidator)
+    {
+        $this->inputValidator = $inputValidator;
+    }
+    
+    /**
+     * @return null|string
+     */
+    public function getExtractor()
+    {
+        return $this->extractor;
+    }
+    
+    /**
+     * @param null|string $extractor
+     * @return void
+     */
+    public function setExtractor($extractor)
+    {
+        $this->extractor = $extractor;
+    }
+    
+    /**
+     * @return \mixed[]|null
+     */
+    public function getKeyMap()
+    {
+        return $this->keyMap;
+    }
+    
+    /**
+     * @param \mixed[]|null $keyMap
+     * @return void
+     */
+    public function setKeyMap($keyMap)
+    {
+        $this->keyMap = $keyMap;
+    }
+    
+    /**
+     * @return null|string
+     */
+    public function getTransformer()
+    {
+        return $this->transformer;
+    }
+    
+    /**
+     * @param null|string $transformer
+     * @return void
+     */
+    public function setTransformer($transformer)
+    {
+        $this->transformer = $transformer;
+    }
+    
+    /**
+     * @return null|string
+     */
+    public function getHydrator()
+    {
+        return $this->hydrator;
+    }
+    
+    /**
+     * @param null|string $hydrator
+     * @return void
+     */
+    public function setHydrator($hydrator)
+    {
+        $this->hydrator = $hydrator;
+    }
+    
+    /**
+     * @return null|string
+     */
+    public function getOutputClass()
+    {
+        return $this->outputClass;
+    }
+    
+    /**
+     * @param null|string $outputClass
+     * @return void
+     */
+    public function setOutputClass($outputClass)
+    {
+        $this->outputClass = $outputClass;
+    }
+    
+    /**
+     * @return null|string
+     */
+    public function getOutputValidator()
+    {
+        return $this->outputValidator;
+    }
+    
+    /**
+     * @param null|string $outputValidator
+     * @return void
+     */
+    public function setOutputValidator($outputValidator)
+    {
+        $this->outputValidator = $outputValidator;
+    }
+}

--- a/src/ZendTransformer/Exception/ExceptionInterface.php
+++ b/src/ZendTransformer/Exception/ExceptionInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer\Exception;
+
+interface ExceptionInterface
+{
+    
+}

--- a/src/ZendTransformer/Exception/TransformationException.php
+++ b/src/ZendTransformer/Exception/TransformationException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer\Exception;
+
+class TransformationException extends \RuntimeException implements ExceptionInterface
+{
+    
+}

--- a/src/ZendTransformer/Factory/AbstractTransformerFactory.php
+++ b/src/ZendTransformer/Factory/AbstractTransformerFactory.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer\Factory;
+
+use Abacaphiliac\Zend\Transformer\Config\TransformerConfig;
+use Abacaphiliac\Zend\Transformer\Transformer;
+use Assert\Assertion;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ExtractionInterface;
+use Zend\Hydrator\HydrationInterface;
+use Zend\Hydrator\HydratorPluginManager;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Validator\IsInstanceOf;
+use Zend\Validator\ValidatorChain;
+use Zend\Validator\ValidatorInterface;
+use Zend\Validator\ValidatorPluginManager;
+
+class AbstractTransformerFactory implements AbstractFactoryInterface
+{
+    private static $pluginManagers = [
+        'HydratorManager' => HydratorPluginManager::class,
+        'ValidatorManager' => ValidatorPluginManager::class,
+    ];
+    
+    /**
+     * Can the factory create an instance for the service?
+     *
+     * @param ServiceLocatorInterface $container
+     * @param string $name
+     * @param string $requestedName
+     * @return bool
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    {
+        if ($container instanceof AbstractPluginManager) {
+            $container = $container->getServiceLocator();
+        }
+        
+        return is_array($this->getTransformerConfig($container, $requestedName));
+    }
+    
+    /**
+     * Create an object
+     *
+     * @param ServiceLocatorInterface $container
+     * @param string $name
+     * @param string $requestedName
+     * @return Transformer
+     * @throws \Zend\Validator\Exception\InvalidArgumentException
+     * @throws \Assert\AssertionFailedException
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @internal param array|null $options
+     */
+    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    {
+        if ($container instanceof AbstractPluginManager) {
+            $container = $container->getServiceLocator();
+        }
+        
+        $config = new TransformerConfig($this->getTransformerConfig($container, $requestedName));
+    
+        $inputValidator = $this->getValidator($container, $config->getInputValidator(), $config->getInputClass());
+        $extractor = $this->getExtractor($container, $config->getExtractor());
+        $transformer = $this->getTransformer($container, $config);
+        $hydrator = $this->getHydrator($container, $config->getHydrator());
+        $outputValidator = $this->getValidator($container, $config->getOutputValidator(), $config->getOutputClass());
+        
+        return new Transformer(
+            $inputValidator,
+            $extractor,
+            $transformer,
+            $hydrator,
+            $outputValidator
+        );
+    }
+    
+    /**
+     * @param ServiceLocatorInterface $container
+     * @param string $requestedName
+     * @return mixed[]
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    private function getTransformerConfig(ServiceLocatorInterface $container, $requestedName)
+    {
+        $applicationConfig = $container->get('config');
+    
+        return \igorw\get_in($applicationConfig, ['abacaphiliac/zend-transformer', 'transformers', $requestedName]);
+    }
+    
+    /**
+     * @param ServiceLocatorInterface $container
+     * @param string $service
+     * @param string $validateIsInstanceOf
+     * @return ValidatorInterface
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @throws \Assert\AssertionFailedException
+     * @throws \Zend\Validator\Exception\InvalidArgumentException
+     * @internal param TransformerConfig $config
+     */
+    private function getValidator(ServiceLocatorInterface $container, $service, $validateIsInstanceOf = null)
+    {
+        if ($service instanceof ValidatorInterface) {
+            return $service;
+        }
+        
+        if ($service === null) {
+            $validator = new ValidatorChain();
+            
+            if ($validateIsInstanceOf) {
+                $validator->attach(new IsInstanceOf(['className' => $validateIsInstanceOf]));
+            }
+            
+            return $validator;
+        }
+        
+        $validator = $this->getService($container, $service, 'ValidatorManager');
+        Assertion::isInstanceOf($validator, ValidatorInterface::class);
+        
+        /** @var ValidatorInterface $validator */
+        return $validator;
+    }
+    
+    /**
+     * @param ServiceLocatorInterface $container
+     * @param string $service
+     * @return ExtractionInterface
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @throws \Assert\AssertionFailedException
+     */
+    private function getExtractor(ServiceLocatorInterface $container, $service)
+    {
+        if ($service instanceof ExtractionInterface) {
+            return $service;
+        }
+        
+        if ($service === null) {
+            return new ClassMethods();
+        }
+        
+        $extractor = $this->getService($container, $service, 'HydratorManager');
+        Assertion::isInstanceOf($extractor, ExtractionInterface::class);
+        
+        /** @var ExtractionInterface $extractor */
+        return $extractor;
+    }
+    
+    /**
+     * @param ServiceLocatorInterface $container
+     * @param string $service
+     * @return HydrationInterface
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @throws \Assert\AssertionFailedException
+     */
+    private function getHydrator(ServiceLocatorInterface $container, $service)
+    {
+        if ($service instanceof HydrationInterface) {
+            return $service;
+        }
+        
+        if ($service === null) {
+            return new ClassMethods();
+        }
+        
+        $validator = $this->getService($container, $service, 'HydratorManager');
+        Assertion::isInstanceOf($validator, HydrationInterface::class);
+        
+        /** @var HydrationInterface $validator */
+        return $validator;
+    }
+    
+    /**
+     * @param ServiceLocatorInterface $container
+     * @param string $pluginManagerName
+     * @param string $service
+     * @return Object
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     * @throws \Assert\AssertionFailedException
+     */
+    private function getService(ServiceLocatorInterface $container, $service, $pluginManagerName)
+    {
+        $plugins = null;
+        
+        if ($container->has($pluginManagerName)) {
+            // Get the named plugin-manager from parent container.
+            $plugins = $container->get($pluginManagerName);
+            Assertion::isInstanceOf($plugins, AbstractPluginManager::class);
+        } elseif (isset(self::$pluginManagers[$pluginManagerName])) {
+            // Create a new plugin-manager.
+            $plugins = new self::$pluginManagers[$pluginManagerName];
+            Assertion::isInstanceOf($plugins, AbstractPluginManager::class);
+            
+            /** @var AbstractPluginManager $plugins */
+            $plugins->setServiceLocator($container);
+        }
+        
+        if ($plugins instanceof ServiceLocatorInterface && $plugins->has($service)) {
+            // Get the service/plugin from the plugin-manager.
+            return $plugins->get($service);
+        }
+    
+        // Fall-back to parent container for service since it could not be provided by a plugin-manager.
+        return $container->get($service);
+    }
+    
+    /**
+     * @param ServiceLocatorInterface $container
+     * @param TransformerConfig $config
+     * @return callable
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    private function getTransformer(ServiceLocatorInterface $container, TransformerConfig $config)
+    {
+        $transformer = $config->getTransformer();
+        if (is_callable($transformer)) {
+            return $transformer;
+        }
+    
+        $keyMap = $config->getKeyMap();
+        if (is_array($keyMap)) {
+            return function (array $data) use ($keyMap) {
+                $result = [];
+                foreach ($data as $key => $value) {
+                    $result[\igorw\get_in($keyMap, [$key], $key)] = $value;
+                }
+                
+                return $result;
+            };
+        }
+        
+        $transformer = $container->get($transformer);
+        Assertion::isCallable($transformer);
+        
+        return $transformer;
+    }
+}

--- a/src/ZendTransformer/Module.php
+++ b/src/ZendTransformer/Module.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer;
+
+use Zend\ModuleManager\Feature\ConfigProviderInterface;
+
+class Module implements ConfigProviderInterface
+{
+    /**
+     * Returns configuration to merge with application configuration
+     *
+     * @return array|\Traversable
+     */
+    public function getConfig()
+    {
+        return require __DIR__ . '/../../config/module.config.php';
+    }
+}

--- a/src/ZendTransformer/PluginManager/TransformerPluginManager.php
+++ b/src/ZendTransformer/PluginManager/TransformerPluginManager.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer\PluginManager;
+
+use Abacaphiliac\Zend\Transformer\Factory\AbstractTransformerFactory;
+use Abacaphiliac\Zend\Transformer\TransformerInterface;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception;
+
+class TransformerPluginManager extends AbstractPluginManager
+{
+    /**
+     * TransformerPluginManager constructor.
+     * @param mixed $configOrContainerInstance
+     * @param array $v3config
+     * @throws \Zend\ServiceManager\Exception\InvalidArgumentException
+     */
+    public function __construct($configOrContainerInstance = null, array $v3config = [])
+    {
+        parent::__construct($configOrContainerInstance, $v3config);
+        
+        $this->abstractFactories[] = new AbstractTransformerFactory();
+    }
+    
+    /**
+     * Validate the plugin
+     *
+     * Checks that the filter loaded is either a valid callback or an instance
+     * of FilterInterface.
+     *
+     * @param  mixed $plugin
+     * @return void
+     * @throws Exception\RuntimeException if invalid
+     */
+    public function validatePlugin($plugin)
+    {
+        if (!$plugin instanceof TransformerInterface) {
+            throw new Exception\RuntimeException(sprintf(
+                'Expected class %s. Actual type %s class %s.',
+                TransformerInterface::class,
+                gettype($plugin),
+                is_object($plugin) ? get_class($plugin) : null
+            ));
+        }
+    }
+}

--- a/src/ZendTransformer/PluginManager/TransformerPluginManagerFactory.php
+++ b/src/ZendTransformer/PluginManager/TransformerPluginManagerFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer\PluginManager;
+
+use Zend\Mvc\Service\AbstractPluginManagerFactory;
+
+class TransformerPluginManagerFactory extends AbstractPluginManagerFactory
+{
+    const PLUGIN_MANAGER_CLASS = TransformerPluginManager::class;
+}

--- a/src/ZendTransformer/Transformer.php
+++ b/src/ZendTransformer/Transformer.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer;
+
+use Abacaphiliac\Zend\Transformer\Exception\TransformationException;
+use Assert\Assertion;
+use Assert\AssertionFailedException;
+use Zend\Hydrator\ExtractionInterface;
+use Zend\Hydrator\HydrationInterface;
+use Zend\Validator\ValidatorInterface;
+
+class Transformer implements TransformerInterface
+{
+    /** @var ValidatorInterface */
+    private $inputValidator;
+    
+    /** @var ExtractionInterface */
+    private $extractor;
+    
+    /** @var callable */
+    private $transformer;
+    
+    /** @var HydrationInterface */
+    private $hydrator;
+    
+    /** @var ValidatorInterface */
+    private $outputValidator;
+    
+    /**
+     * Transformer constructor.
+     * @param ValidatorInterface $inputValidator
+     * @param ExtractionInterface $extractor
+     * @param callable $transformer
+     * @param HydrationInterface $hydrator
+     * @param ValidatorInterface $outputValidator
+     */
+    public function __construct(
+        ValidatorInterface $inputValidator,
+        ExtractionInterface $extractor,
+        callable $transformer,
+        HydrationInterface $hydrator,
+        ValidatorInterface $outputValidator
+    ) {
+        $this->inputValidator = $inputValidator;
+        $this->extractor = $extractor;
+        $this->transformer = $transformer;
+        $this->hydrator = $hydrator;
+        $this->outputValidator = $outputValidator;
+    }
+    
+    /**
+     * @param mixed $input
+     * @param mixed|string $output
+     * @return mixed
+     * @throws \Abacaphiliac\Zend\Transformer\Exception\TransformationException
+     */
+    public function transform($input, $output)
+    {
+        try {
+            if (is_string($output)) {
+                Assertion::classExists($output);
+                $output = new $output;
+            }
+            
+            $this->validateObject($input, $this->inputValidator);
+        
+            $inputData = $this->extract($input);
+        
+            $outputData = $this->transformInputData($inputData);
+        
+            $output = $this->hydrate($outputData, $output);
+        
+            $this->validateObject($output, $this->outputValidator);
+        } catch (AssertionFailedException $e) {
+            throw new TransformationException('Transformation failed.', 0, $e);
+        } catch (\Exception $e) {
+            throw new TransformationException('Transformation failed.', 0, $e);
+        }
+        
+        return $output;
+    }
+    
+    /**
+     * @param mixed $object
+     * @param ValidatorInterface $validator
+     * @return bool
+     * @throws \Zend\Validator\Exception\RuntimeException
+     * @throws AssertionFailedException
+     */
+    private function validateObject($object, ValidatorInterface $validator)
+    {
+        Assertion::isObject($object);
+    
+        $isValid = $validator->isValid($object);
+    
+        Assertion::true($isValid, 'Validation failed: ' . json_encode($validator->getMessages()));
+        
+        return true;
+    }
+    
+    /**
+     * @param mixed $object
+     * @return mixed[]
+     * @throws AssertionFailedException
+     */
+    private function extract($object)
+    {
+        Assertion::isObject($object);
+        
+        $data = $this->extractor->extract($object);
+        
+        Assertion::isArray($data);
+        
+        return $data;
+    }
+    
+    /**
+     * @param mixed[] $input
+     * @return mixed[]
+     * @throws AssertionFailedException
+     */
+    private function transformInputData(array $input)
+    {
+        $output = call_user_func($this->transformer, $input);
+        
+        Assertion::isArray($output);
+        
+        return $output;
+    }
+    
+    /**
+     * @param mixed[] $data
+     * @param mixed|string $object
+     * @return mixed
+     * @throws AssertionFailedException
+     */
+    private function hydrate(array $data, $object)
+    {
+        Assertion::isObject($object);
+        
+        $output = $this->hydrator->hydrate($data, $object);
+        
+        Assertion::isObject($output);
+        
+        return $output;
+    }
+}

--- a/src/ZendTransformer/TransformerInterface.php
+++ b/src/ZendTransformer/TransformerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Abacaphiliac\Zend\Transformer;
+
+interface TransformerInterface
+{
+    /**
+     * @param object $input
+     * @param object $output Class name or model.
+     * @return object
+     * @throws \Abacaphiliac\Zend\Transformer\Exception\ExceptionInterface
+     */
+    public function transform($input, $output);
+}

--- a/tests/ZendTransformer/Config/TransformerConfigTest.php
+++ b/tests/ZendTransformer/Config/TransformerConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace AbacaphiliacTest\Zend\Transformer\Config;
+
+use Abacaphiliac\Zend\Transformer\Config\TransformerConfig;
+use Abacaphiliac\Zend\Transformer\TransformerInterface;
+use AbacaphiliacTest\FizBuz;
+use AbacaphiliacTest\FooBar;
+use Zend\Hydrator\ClassMethods;
+use Zend\Validator\ValidatorChain;
+
+/**
+ * @covers \Abacaphiliac\Zend\Transformer\Config\TransformerConfig
+ */
+class TransformerConfigTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateFromSnakeCaseOptions()
+    {
+        $config = new TransformerConfig([
+            'input_class' => FooBar::class,
+            'input_validator' => ValidatorChain::class,
+            'extractor' => ClassMethods::class,
+            'keyMap' => [
+                'foo' => 'fiz',
+                'bar' => 'buz',
+            ],
+            'transformer' => TransformerInterface::class,
+            'hydrator' => ClassMethods::class,
+            'output_class' => FizBuz::class,
+            'output_validator' => ValidatorChain::class,
+        ]);
+        
+        self::assertEquals(FooBar::class, $config->getInputClass());
+        self::assertEquals(ValidatorChain::class, $config->getInputValidator());
+        self::assertEquals(ClassMethods::class, $config->getExtractor());
+        self::assertEquals(['foo' => 'fiz', 'bar' => 'buz'], $config->getKeyMap());
+        self::assertEquals(TransformerInterface::class, $config->getTransformer());
+        self::assertEquals(ClassMethods::class, $config->getHydrator());
+        self::assertEquals(FizBuz::class, $config->getOutputClass());
+        self::assertEquals(ValidatorChain::class, $config->getOutputValidator());
+    }
+    
+    public function testCreateFromCamelCaseOptions()
+    {
+        $config = new TransformerConfig([
+            'inputClass' => FooBar::class,
+            'inputValidator' => ValidatorChain::class,
+            'extractor' => ClassMethods::class,
+            'keyMap' => [
+                'foo' => 'fiz',
+                'bar' => 'buz',
+            ],
+            'transformer' => TransformerInterface::class,
+            'hydrator' => ClassMethods::class,
+            'outputClass' => FizBuz::class,
+            'outputValidator' => ValidatorChain::class,
+        ]);
+        
+        self::assertEquals(FooBar::class, $config->getInputClass());
+        self::assertEquals(ValidatorChain::class, $config->getInputValidator());
+        self::assertEquals(ClassMethods::class, $config->getExtractor());
+        self::assertEquals(['foo' => 'fiz', 'bar' => 'buz'], $config->getKeyMap());
+        self::assertEquals(TransformerInterface::class, $config->getTransformer());
+        self::assertEquals(ClassMethods::class, $config->getHydrator());
+        self::assertEquals(FizBuz::class, $config->getOutputClass());
+        self::assertEquals(ValidatorChain::class, $config->getOutputValidator());
+    }
+}

--- a/tests/ZendTransformer/Factory/AbstractTransformerFactoryTest.php
+++ b/tests/ZendTransformer/Factory/AbstractTransformerFactoryTest.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace AbacaphiliacTest\Zend\Transformer\Factory;
+
+use Abacaphiliac\Zend\Transformer\Factory\AbstractTransformerFactory;
+use Abacaphiliac\Zend\Transformer\TransformerInterface;
+use AbacaphiliacTest\FizBuz;
+use AbacaphiliacTest\FooBar;
+use Zend\Hydrator\ClassMethods;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Validator\ValidatorChain;
+
+/**
+ * @covers \Abacaphiliac\Zend\Transformer\Factory\AbstractTransformerFactory
+ */
+class AbstractTransformerFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var AbstractTransformerFactory */
+    private $sut;
+    
+    /** @var ServiceManager */
+    private $container;
+    
+    protected function setUp()
+    {
+        $this->container = new ServiceManager();
+        
+        $this->sut = $sut = new AbstractTransformerFactory();
+    }
+    
+    public function testTransformFromSimpleSpec()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'outputClass' => FizBuz::class,
+                    ],
+                ],
+            ],
+        ]);
+    
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+    
+    /**
+     * @expectedException \Abacaphiliac\Zend\Transformer\Exception\TransformationException
+     */
+    public function testNotTransformDueToInvalidInputClass()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FizBuz::class,
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'outputClass' => FooBar::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+    }
+    
+    /**
+     * @expectedException \Abacaphiliac\Zend\Transformer\Exception\TransformationException
+     */
+    public function testNotTransformDueToInvalidOutputClass()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'outputClass' => FooBar::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+    }
+    
+    public function testTransformCustomExtractor()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'extractor' => 'ClassMethods',
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'outputClass' => FizBuz::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+    
+    public function testTransformCustomExtractorInstance()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'extractor' => new ClassMethods(),
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'outputClass' => FizBuz::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+    
+    public function testTransformCustomHydrator()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'hydrator' => 'ClassMethods',
+                        'outputClass' => FizBuz::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+    
+    public function testTransformCustomHydratorInstance()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'hydrator' => new ClassMethods(),
+                        'outputClass' => FizBuz::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+    
+    public function testTransformCustomKeyMapCallable()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'transformer' => function (array $data) {
+                            return [
+                                'fiz' => $data['foo'],
+                                'buz' => $data['bar'],
+                            ];
+                        },
+                        'outputClass' => FizBuz::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+    
+    public function testTransformCustomKeyMapService()
+    {
+        $this->container->setService('CustomKeyMapService', function (array $data) {
+            return [
+                'fiz' => $data['foo'],
+                'buz' => $data['bar'],
+            ];
+        });
+        
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'transformer' => 'CustomKeyMapService',
+                        'outputClass' => FizBuz::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+    
+    public function testTransformCustomInputValidatorInstance()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'inputValidator' => new ValidatorChain(),
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'outputClass' => FizBuz::class,
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+    
+    public function testTransformCustomOutputValidatorInstance()
+    {
+        $this->container->setService('config', [
+            'abacaphiliac/zend-transformer' => [
+                'transformers' => [
+                    'FooBarToFizBuz' => [
+                        'inputClass' => FooBar::class,
+                        'keyMap' => [
+                            'foo' => 'fiz',
+                            'bar' => 'buz',
+                        ],
+                        'outputClass' => FizBuz::class,
+                        'outputValidator' => new ValidatorChain(),
+                    ],
+                ],
+            ],
+        ]);
+        
+        self::assertTrue($this->sut->canCreateServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz'));
+        
+        $transformer = $this->sut->createServiceWithName($this->container, 'FooBarToFizBuz', 'FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+        
+        $result = $transformer->transform(new FooBar('Alice', 'Bob'), new FizBuz());
+        self::assertInstanceOf(FizBuz::class, $result);
+        
+        /** @var FizBuz $result */
+        self::assertEquals('Alice', $result->getFiz());
+        self::assertEquals('Bob', $result->getBuz());
+    }
+}

--- a/tests/ZendTransformer/FizBuz.php
+++ b/tests/ZendTransformer/FizBuz.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AbacaphiliacTest;
+
+class FizBuz
+{
+    /** @var mixed|null */
+    private $fiz;
+    
+    /** @var mixed|null */
+    private $buz;
+    
+    /**
+     * FizBuz constructor.
+     * @param mixed|null $fiz
+     * @param mixed|null $buz
+     */
+    public function __construct($fiz = null, $buz = null)
+    {
+        $this->fiz = $fiz;
+        $this->buz = $buz;
+    }
+    
+    /**
+     * @return mixed|null
+     */
+    public function getFiz()
+    {
+        return $this->fiz;
+    }
+    
+    /**
+     * @param mixed|null $fiz
+     * @return void
+     */
+    public function setFiz($fiz)
+    {
+        $this->fiz = $fiz;
+    }
+    
+    /**
+     * @return mixed|null
+     */
+    public function getBuz()
+    {
+        return $this->buz;
+    }
+    
+    /**
+     * @param mixed|null $buz
+     * @return void
+     */
+    public function setBuz($buz)
+    {
+        $this->buz = $buz;
+    }
+}

--- a/tests/ZendTransformer/FooBar.php
+++ b/tests/ZendTransformer/FooBar.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AbacaphiliacTest;
+
+class FooBar
+{
+    /** @var mixed|null */
+    private $foo;
+    
+    /** @var mixed|null */
+    private $bar;
+    
+    /**
+     * FooBar constructor.
+     * @param mixed|null $foo
+     * @param mixed|null $bar
+     */
+    public function __construct($foo = null, $bar = null)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+    
+    /**
+     * @return mixed|null
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+    
+    /**
+     * @param mixed|null $foo
+     * @return void
+     */
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+    
+    /**
+     * @return mixed|null
+     */
+    public function getBar()
+    {
+        return $this->bar;
+    }
+    
+    /**
+     * @param mixed|null $bar
+     * @return void
+     */
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+}

--- a/tests/ZendTransformer/ModuleTest.php
+++ b/tests/ZendTransformer/ModuleTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AbacaphiliacTest\Zend\Transformer;
+
+use Abacaphiliac\Zend\Transformer\Module;
+
+/**
+ * @covers \Abacaphiliac\Zend\Transformer\Module
+ */
+class ModuleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetConfig()
+    {
+        $config = (new Module())->getConfig();
+        
+        self::assertArraySubset($config, unserialize(serialize($config)));
+    }
+}

--- a/tests/ZendTransformer/PluginManager/TransformerPluginManagerTest.php
+++ b/tests/ZendTransformer/PluginManager/TransformerPluginManagerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace AbacaphiliacTest\Zend\Transformer\PluginManager;
+
+use Abacaphiliac\Zend\Transformer\Module;
+use Abacaphiliac\Zend\Transformer\PluginManager\TransformerPluginManager;
+use Abacaphiliac\Zend\Transformer\TransformerInterface;
+use AbacaphiliacTest\FizBuz;
+use AbacaphiliacTest\FooBar;
+use Zend\Mvc\Service\ServiceManagerConfig;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @covers \Abacaphiliac\Zend\Transformer\PluginManager\TransformerPluginManager
+ */
+class TransformerPluginManagerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateTransformerViaModuleConfig()
+    {
+        $module = new Module();
+        $config = $module->getConfig();
+        
+        $config['abacaphiliac/zend-transformer']['transformers']['FooBarToFizBuz'] = [
+            'inputClass' => FooBar::class,
+            'keyMap' => [
+                'foo' => 'fiz',
+                'bar' => 'buz',
+            ],
+            'outputClass' => FizBuz::class,
+        ];
+        
+        $serviceManagerConfig = new ServiceManagerConfig(\igorw\get_in($config, ['service_manager'], []));
+        
+        $container = new ServiceManager();
+        $serviceManagerConfig->configureServiceManager($container);
+        $container->setService('config', $config);
+    
+        $transformers = $container->get('TransformerManager');
+        self::assertInstanceOf(TransformerPluginManager::class, $transformers);
+    
+        $transformer = $transformers->get('FooBarToFizBuz');
+        self::assertInstanceOf(TransformerInterface::class, $transformer);
+    }
+}

--- a/tests/ZendTransformer/TransformerTest.php
+++ b/tests/ZendTransformer/TransformerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace AbacaphiliacTest\Zend\Transformer;
+
+use Abacaphiliac\Zend\Transformer\Transformer;
+use AbacaphiliacTest\FizBuz;
+use AbacaphiliacTest\FooBar;
+use Zend\Hydrator\ClassMethods;
+use Zend\Validator\ValidatorChain;
+
+/**
+ * @covers \Abacaphiliac\Zend\Transformer\Transformer
+ */
+class TransformerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTransform()
+    {
+        $sut = new Transformer(
+            new ValidatorChain(),
+            new ClassMethods(),
+            function (array $data) {
+                return [
+                    'fiz' => $data['foo'],
+                    'buz' => $data['bar'],
+                ];
+            },
+            new ClassMethods(),
+            new ValidatorChain()
+        );
+    
+        $input = new FooBar();
+        $input->setFoo('Alice');
+        $input->setBar('Bob');
+        
+        $output = $sut->transform($input, FizBuz::class);
+        self::assertInstanceOf(FizBuz::class, $output);
+        
+        /** @var FizBuz $output */
+        self::assertEquals('Alice', $output->getFiz());
+        self::assertEquals('Bob', $output->getBuz());
+    }
+}


### PR DESCRIPTION
object-to-object ETL package, based on zend-framework extraction, hydration, and validation abstractions. includes plugin-manager for registering transformation specs via application config, and a ZF2 module to wire up all configuration. supports >=php55 at this time, but not ZF3.