### PR TITLE
remove proprietary license, whoops.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "abacaphiliac/zend-transformer",
     "description": "Extract and Hydrate, plus secret sauce.",
     "minimum-stability": "stable",
-    "license": "proprietary",
+    "license": "MIT",
     "authors": [
         {
             "name": "Timothy Younger",


### PR DESCRIPTION
proprietary was an accident. syncing with the LICENSE file:
https://github.com/abacaphiliac/zend-transformer/blob/master/LICENSE